### PR TITLE
release_tag hernoemd naar release in ReferentiedataTest

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ testframework.test(
     test=ReferentiedataTest(
         soort="RUIMTEDETAILSOORT",
         attribuut="Code",
-        release_tag="latest",  # standaard is latest, maar kan ook een specifieke versie zijn zoals v4.1.240419
+        release="latest",  # standaard is latest, maar kan ook een specifieke versie zijn zoals v4.1.240419
     ),
     nullable=False,  # of een waarde leeg mag zijn. Dit is aan de gebruiker
 ).show()

--- a/src/vera_testframework/pyspark/referentiedata.py
+++ b/src/vera_testframework/pyspark/referentiedata.py
@@ -13,7 +13,7 @@ class ReferentiedataTest(ValidCategory):  # type: ignore
         name (Optional[str]): The name of the test. If not provided, defaults to "VERAStandaard".
         soort (str): The type/category of the data, which will be converted to uppercase.
         attribuut (Literal["Code", "Naam"]): The attribute to use, either "Code" or "Naam". It will be capitalized.
-        release_tag (str): The tag of the release to use. Default is "latest".
+        release (str): The tag of the release to use. Default is "latest".
 
     Raises:
         TypeError: If soort is not a string.
@@ -28,7 +28,7 @@ class ReferentiedataTest(ValidCategory):  # type: ignore
         name: Optional[str] = None,
         soort: str,
         attribuut: Literal["Code", "Naam"],
-        release_tag: str = "latest",
+        release: str = "latest",
     ):
         if not isinstance(soort, str):
             raise TypeError("soort must be a string")
@@ -40,9 +40,9 @@ class ReferentiedataTest(ValidCategory):  # type: ignore
 
         name = name if name else "VERAStandaard"
 
-        self.referentiedata = self._get_cached_data(release_tag)
+        self.referentiedata = self._get_cached_data(release)
         super().__init__(name=name, categories=self._categorieen())
-        self.release_tag = release_tag
+        self.release = release
 
     @classmethod
     def _get_cached_data(cls, release_tag: str) -> list[dict[str, str]]:
@@ -65,7 +65,7 @@ class ReferentiedataTest(ValidCategory):  # type: ignore
         return {row[self.attribuut] for row in categorieen_rows}
 
     def __str__(self) -> str:
-        return f"ReferentiedataTest({self.soort}, {self.attribuut})"
+        return f"ReferentiedataTest({self.soort}, {self.attribuut}, {self.release})"
 
     def __repr__(self) -> str:
         return self.__str__()

--- a/src/vera_testframework/pyspark/referentiedata.py
+++ b/src/vera_testframework/pyspark/referentiedata.py
@@ -65,7 +65,7 @@ class ReferentiedataTest(ValidCategory):  # type: ignore
         return {row[self.attribuut] for row in categorieen_rows}
 
     def __str__(self) -> str:
-        return f"ReferentiedataTest({self.soort}, {self.attribuut}, {self.release})"
+        return f"ReferentiedataTest({self.soort}, {self.attribuut}, v={self.release})"
 
     def __repr__(self) -> str:
         return self.__str__()

--- a/tests/pyspark/referentiedata/test_ReferentiedataTest.py
+++ b/tests/pyspark/referentiedata/test_ReferentiedataTest.py
@@ -96,5 +96,5 @@ def test_str_and_repr():
 def test_wrong_release_tag():
     with pytest.raises(Exception):
         ReferentiedataTest(
-            soort="RUIMTEDETAILSOORT", attribuut="Code", release_tag="invalid"
+            soort="RUIMTEDETAILSOORT", attribuut="Code", release="invalid"
         )

--- a/tests/pyspark/referentiedata/test_ReferentiedataTest.py
+++ b/tests/pyspark/referentiedata/test_ReferentiedataTest.py
@@ -85,11 +85,11 @@ def test_wrong_type_soort():
 def test_str_and_repr():
     assert (
         str(ReferentiedataTest(soort="RUIMTEDETAILSOORT", attribuut="Code"))
-        == "ReferentiedataTest(RUIMTEDETAILSOORT, Code)"
+        == "ReferentiedataTest(RUIMTEDETAILSOORT, Code, v=latest)"
     )
     assert (
         repr(ReferentiedataTest(soort="RUIMTEDETAILSOORT", attribuut="Code"))
-        == "ReferentiedataTest(RUIMTEDETAILSOORT, Code)"
+        == "ReferentiedataTest(RUIMTEDETAILSOORT, Code, v=latest)"
     )
 
 

--- a/tutorial.ipynb
+++ b/tutorial.ipynb
@@ -128,7 +128,7 @@
     "    test=ReferentiedataTest(\n",
     "        soort=\"RUIMTEDETAILSOORT\",\n",
     "        attribuut=\"Code\",\n",
-    "        release_tag=\"latest\",  # standaard is latest, maar kan ook een specifieke versie zijn zoals v4.1.240419\n",
+    "        release=\"latest\",  # standaard is latest, maar kan ook een specifieke versie zijn zoals v4.1.240419\n",
     "    ),\n",
     "    nullable=False,  # of een waarde leeg mag zijn. Dit is aan de gebruiker\n",
     ").show()"


### PR DESCRIPTION
1. **Parameternaam Wijziging:**
   - De parameternaam `release_tag` is gewijzigd naar `release` in de `ReferentiedataTest` klasse en de bijbehorende methoden en documentatie. Dit maakt de naamgeving consistenter en eenvoudiger.

2. **Updates aan de Documentatie:**
   - De README.md en tutorial notebook zijn aangepast om de nieuwe parameternaam weer te geven. Voorbeeldcode en uitleg zijn dienovereenkomstig bijgewerkt.

3. **Aanpassing van String Representaties:**
   - De `__str__` en `__repr__` methoden van de `ReferentiedataTest` klasse zijn bijgewerkt om de nieuwe parameternaam in de string representatie weer te geven.

4. **Testcases Bijgewerkt:**
   - De testcases in `test_ReferentiedataTest.py` zijn aangepast om de nieuwe parameternaam te gebruiken. Dit omvat het testen van ongeldige waarden voor de `release` parameter.